### PR TITLE
Fixed OS name issue

### DIFF
--- a/src/main/java/com/browserstack/utils/OsUtils.java
+++ b/src/main/java/com/browserstack/utils/OsUtils.java
@@ -7,7 +7,7 @@ public class OsUtils {
         if (OS == null) {
             OS = System.getProperty("os.name");
         }
-        return OS;
+        return OS.toLowerCase();
     }
 
     public static boolean isWindows() {


### PR DESCRIPTION
OS name was coming in uppercase and we were comparing it with lowercase and it was not able to find the driver path. I made OS name to lowercase while returning.